### PR TITLE
Fix puzzle game asset paths for GitHub Pages

### DIFF
--- a/puzzle/index.html
+++ b/puzzle/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
-    <script type="module" crossorigin src="/assets/index-CPVyKU44.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D35eQNx3.css">
+    <script type="module" crossorigin src="./assets/index-CPVyKU44.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-D35eQNx3.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- update the puzzle build's asset and icon paths to be relative
- ensure GitHub Pages resolves the bundled script and stylesheet correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69068c30785c8328840513f1ef782121