### PR TITLE
Fix asset paths for puzzle game build

### DIFF
--- a/math-dungeon-app/vite.config.ts
+++ b/math-dungeon-app/vite.config.ts
@@ -2,7 +2,7 @@
 import react from '@vitejs/plugin-react'
 
 const repoPath = process.env.GITHUB_REPOSITORY?.split('/')?.[1]
-const base = process.env.GITHUB_ACTIONS && repoPath ? `/${repoPath}/` : '/'
+const base = process.env.GITHUB_ACTIONS && repoPath ? `/${repoPath}/puzzle/` : './'
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- update Vite base configuration so static builds serve assets relative to the puzzle directory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69068f0645688328bc16fd64b414899c