### PR TITLE
Add redirect page for complete edition

### DIFF
--- a/math-dungeon-app/public/math-game-complete.html
+++ b/math-dungeon-app/public/math-game-complete.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=../math-game-complete.html" />
+    <title>Math Dungeon - Complete Edition</title>
+    <link rel="canonical" href="../math-game-complete.html" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at top, #4f46e5, #1f2937);
+        color: #f9fafb;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        text-align: center;
+      }
+      a {
+        color: #38bdf8;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>完全版へ移動しています…</h1>
+      <p>
+        自動的に移動しない場合は
+        <a href="../math-game-complete.html">こちらをクリック</a>
+        してください。
+      </p>
+      <p>
+        <strong>メモ:</strong> 完全版は <code>https://awano27.github.io/Multilingual-Math-Game/math-game-complete.html</code>
+        でいつでも開けます。
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a static redirect page in the Vite public assets so puzzle/math-game-complete.html forwards to the main complete edition
- document the canonical URL directly in the redirect page for players who open it manually

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69069bccb070832882788cf12aaf8bce