### PR TITLE
Refactor math adventure for kids

### DIFF
--- a/math-dungeon-app/src/App.css
+++ b/math-dungeon-app/src/App.css
@@ -1,13 +1,15 @@
 :root {
-  font-family: 'Segoe UI', 'Hiragino Kaku Gothic Pro', 'Yu Gothic', sans-serif;
+  font-family: 'Baloo 2', 'Hiragino Kaku Gothic Pro', 'Yu Gothic', 'Segoe UI', sans-serif;
   color: #0f172a;
-  background-color: #0f172a;
+  background-color: #f6f9ff;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, #1f2937 0%, #0f172a 60%, #0b1120 100%);
+  background: radial-gradient(circle at 20% 20%, #fef08a 0%, rgba(255, 255, 255, 0) 30%),
+    radial-gradient(circle at 85% 15%, #bfdbfe 0%, rgba(255, 255, 255, 0) 25%),
+    linear-gradient(180deg, #f8fafc 0%, #e0f2fe 100%);
 }
 
 #root {
@@ -16,7 +18,7 @@ body {
 
 .game-shell {
   min-height: 100vh;
-  padding: 32px 16px;
+  padding: 28px 16px 48px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -24,113 +26,229 @@ body {
 
 .game-card {
   width: 100%;
-  max-width: 1100px;
-  background: rgba(255, 255, 255, 0.94);
-  border-radius: 28px;
+  max-width: 1200px;
+  background: #ffffff;
+  border-radius: 30px;
   padding: 32px;
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 24px 60px rgba(59, 130, 246, 0.2);
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 24px;
+  border: 2px solid #e0f2fe;
 }
 
 .game-header {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
 }
 
 .game-header h1 {
   margin: 0;
-  font-size: 2.5rem;
-  color: #1e3a8a;
+  font-size: 2.6rem;
+  color: #1d4ed8;
 }
 
 .game-header p {
-  margin: 4px 0 0;
+  margin: 6px 0 0;
   font-size: 1.05rem;
   color: #475569;
-  max-width: 32rem;
+  max-width: 34rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-weight: 800;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  color: #f97316;
+  text-transform: uppercase;
+}
+
+.top-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
 }
 
 .language-select {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   font-weight: 600;
   color: #1f2937;
 }
 
 .language-select select {
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
-  padding: 10px 16px;
+  border-radius: 14px;
+  border: 2px solid #bfdbfe;
+  padding: 10px 14px;
   font-size: 1rem;
   background-color: #f8fafc;
-  color: #1f2937;
+  color: #0f172a;
+}
+
+.pill-button {
+  border: none;
+  background: linear-gradient(135deg, #34d399, #22c55e);
+  color: #0b1b2a;
+  padding: 12px 16px;
+  border-radius: 16px;
+  font-weight: 800;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(34, 197, 94, 0.35);
+}
+
+.pill-label {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.pill-value {
+  font-size: 1rem;
 }
 
 .scoreboard {
   display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .stat-card {
-  background: linear-gradient(135deg, #e0f2fe, #f5f3ff);
-  border-radius: 20px;
-  padding: 18px 20px;
+  background: linear-gradient(135deg, #eff6ff, #e0f2fe);
+  border-radius: 18px;
+  padding: 16px 18px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.18);
 }
 
 .stat-label {
   font-size: 0.9rem;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #3b82f6;
+  color: #2563eb;
 }
 
 .stat-value {
-  font-size: 1.7rem;
-  font-weight: 700;
+  font-size: 1.8rem;
+  font-weight: 800;
   color: #0f172a;
+}
+
+.stat-value.highlight {
+  color: #ea580c;
+}
+
+.stat-value.soft {
+  color: #0ea5e9;
+}
+
+.quest-card {
+  background: linear-gradient(120deg, rgba(14, 165, 233, 0.18), rgba(52, 211, 153, 0.2));
+  border-radius: 20px;
+  padding: 16px 18px;
+  border: 2px solid #c7d2fe;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quest-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.muted {
+  margin: 0;
+  color: #475569;
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+}
+
+.badge {
+  background: #fff;
+  border-radius: 12px;
+  padding: 8px 10px;
+  border: 2px dashed #cbd5e1;
+  font-weight: 800;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.badge.active {
+  border-style: solid;
+  border-color: #f59e0b;
+  background: #fffbeb;
+}
+
+.badge-count {
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.quest-progress {
+  background: #e2e8f0;
+  border-radius: 999px;
+  height: 12px;
+  overflow: hidden;
+}
+
+.quest-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #f59e0b, #2563eb);
+  transition: width 200ms ease;
+}
+
+.quest-next {
+  margin: 0;
+  font-weight: 700;
+  color: #1d4ed8;
 }
 
 .game-body {
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 32px;
+  gap: 20px;
 }
 
 .board-area {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
 }
 
 .board {
   display: grid;
-  grid-template-columns: repeat(6, 72px);
+  grid-template-columns: repeat(6, 70px);
   gap: 12px;
-  padding: 18px;
+  padding: 16px;
   border-radius: 24px;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.92));
-  box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.15);
+  background: linear-gradient(135deg, #0ea5e9, #2563eb);
+  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.4);
   touch-action: none;
   user-select: none;
 }
 
 .orb {
-  width: 72px;
-  height: 72px;
-  border-radius: 20px;
-  border: 3px solid rgba(255, 255, 255, 0.45);
+  width: 70px;
+  height: 70px;
+  border-radius: 18px;
+  border: 3px solid rgba(255, 255, 255, 0.7);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -139,23 +257,23 @@ body {
   cursor: grab;
   touch-action: none;
   user-select: none;
-  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.55);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.35);
   transition: transform 120ms ease, box-shadow 120ms ease, outline 120ms ease;
 }
 
 .orb:hover {
   transform: translateY(-4px);
-  box-shadow: 0 20px 34px rgba(15, 23, 42, 0.6);
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.4);
 }
 
 .orb.selected {
-  outline: 4px solid rgba(250, 204, 21, 0.85);
-  transform: scale(1.05);
+  outline: 4px solid rgba(250, 204, 21, 0.9);
+  transform: scale(1.04);
 }
 
 .orb:active {
   cursor: grabbing;
-  transform: scale(1.03);
+  transform: scale(1.02);
 }
 
 .orb.fire {
@@ -200,8 +318,8 @@ body {
   gap: 6px;
   padding: 6px 12px;
   border-radius: 999px;
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: 0.95rem;
+  font-weight: 700;
   background: rgba(148, 163, 184, 0.16);
   color: #1f2937;
 }
@@ -237,127 +355,111 @@ body {
 .status-message {
   margin: 0;
   min-height: 1.5rem;
-  font-weight: 600;
+  font-weight: 700;
   text-align: center;
-  color: #1e3a8a;
+  color: #0f172a;
 }
 
 .reset-button {
   border: none;
-  padding: 12px 28px;
-  border-radius: 16px;
+  padding: 12px 26px;
+  border-radius: 18px;
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 800;
   color: #ffffff;
-  background: linear-gradient(135deg, #6366f1, #3b82f6);
+  background: linear-gradient(135deg, #f97316, #f59e0b);
   cursor: pointer;
-  box-shadow: 0 20px 34px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 18px 32px rgba(244, 114, 182, 0.35);
   transition: transform 120ms ease, box-shadow 120ms ease;
 }
 
 .reset-button:hover {
   transform: translateY(-2px);
-  box-shadow: 0 24px 38px rgba(59, 130, 246, 0.45);
+  box-shadow: 0 20px 36px rgba(244, 114, 182, 0.45);
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 14px;
 }
 
-.instructions,
-.combo-log {
+.panel {
   background: #f8fafc;
-  border-radius: 20px;
-  padding: 20px 24px;
+  border-radius: 18px;
+  padding: 16px 18px;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
 }
 
-.instructions h2,
-.combo-log h2 {
+.panel h2 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #1e293b;
+  font-size: 1.2rem;
+  color: #0f172a;
 }
 
 .instructions ol {
-  margin: 16px 0 0;
+  margin: 12px 0 0;
   padding-left: 20px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   color: #1f2937;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .combo-log ul {
-  margin: 16px 0 0;
+  margin: 12px 0 0;
   padding: 0;
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 8px;
   color: #0f172a;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .combo-log li {
   padding: 8px 12px;
   border-radius: 12px;
-  background: rgba(96, 165, 250, 0.18);
-}
-
-.combo-log .muted {
-  margin: 12px 0 0;
-  color: #64748b;
-  font-style: italic;
+  background: rgba(59, 130, 246, 0.12);
 }
 
 @media (max-width: 1024px) {
   .game-body {
     grid-template-columns: 1fr;
   }
-  .sidebar {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-  .instructions,
-  .combo-log {
-    flex: 1 1 320px;
-  }
 }
 
 @media (max-width: 768px) {
   .game-card {
-    padding: 24px;
+    padding: 20px;
   }
   .board {
-    grid-template-columns: repeat(6, 60px);
+    grid-template-columns: repeat(6, 58px);
     gap: 10px;
-    padding: 14px;
+    padding: 12px;
   }
   .orb {
-    width: 60px;
-    height: 60px;
+    width: 58px;
+    height: 58px;
     border-radius: 16px;
-    font-size: 1.7rem;
+    font-size: 1.6rem;
   }
 }
 
 @media (max-width: 520px) {
   .game-header h1 {
-    font-size: 2rem;
+    font-size: 2.1rem;
   }
   .board {
-    grid-template-columns: repeat(6, 52px);
+    grid-template-columns: repeat(6, 50px);
     gap: 8px;
-    padding: 12px;
+    padding: 10px;
   }
   .orb {
-    width: 52px;
-    height: 52px;
+    width: 50px;
+    height: 50px;
     border-radius: 14px;
-    font-size: 1.5rem;
+    font-size: 1.4rem;
   }
 }

--- a/math-dungeon-app/src/App.tsx
+++ b/math-dungeon-app/src/App.tsx
@@ -1,786 +1,96 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { PointerEvent as ReactPointerEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import './App.css';
+import { Board } from './components/Board';
+import { ComboLog } from './components/ComboLog';
+import { Instructions } from './components/Instructions';
+import { QuestTracker } from './components/QuestTracker';
+import { StatsPanel } from './components/StatsPanel';
+import { TopBar } from './components/TopBar';
+import { MAX_TURNS, NUMBER_LOCALES } from './gameConfig';
+import { useGameEngine } from './hooks/useGameEngine';
+import { TRANSLATIONS } from './translations';
+import type { Locale } from './types';
 
-const BOARD_ROWS = 5;
-const BOARD_COLS = 6;
-const MAX_TURNS = 20;
-
-type ElementType = 'fire' | 'water' | 'wood' | 'light' | 'dark' | 'heart';
-
-type CellPosition = {
-  row: number;
-  col: number;
-};
-
-type ComboDetail = {
-  type: ElementType;
-  size: number;
-  points: number;
-  cascade: number;
-};
-
-type Translation = {
-  languageName: string;
-  gameTitle: string;
-  subtitle: string;
-  languageSelectLabel: string;
-  instructionsTitle: string;
-  instructions: string[];
-  statsLabels: {
-    turns: string;
-    score: string;
-    combos: string;
-  };
-  lastComboTitle: string;
-  noCombosYet: string;
-  resetButton: string;
-  messageInvalidSwap: string;
-  messageCombo: (comboCount: number) => string;
-  messageReady: string;
-  outOfTurns: string;
-  elementNames: Record<ElementType, string>;
-  comboLineTemplate: string;
-  pointsUnit: string;
-  cascadeLabelTemplate: string;
-};
-
-const GEM_TYPES: ElementType[] = ['fire', 'water', 'wood', 'light', 'dark', 'heart'];
-
-const ORB_EMOJI: Record<ElementType, string> = {
-  fire: '🔥',
-  water: '💧',
-  wood: '🌿',
-  light: '✨',
-  dark: '🌙',
-  heart: '💖'
-};
-
-const format = (template: string, params: Record<string, string | number>) =>
-  template.replace(/\{(\w+)\}/g, (match, key) => (key in params ? String(params[key]) : match));
-
-const TRANSLATIONS: Record<'ja' | 'en' | 'es', Translation> = {
-  ja: {
-    languageName: '日本語',
-    gameTitle: '算数パズルダンジョン',
-    subtitle: '珠をなぞって入れ替え、コンボでスコアを伸ばそう！',
-    languageSelectLabel: '表示言語',
-    instructionsTitle: '遊び方',
-    instructions: [
-      '移動したい珠をタップしたまま指を離さずにスライドします。',
-      '指が通ったマスと自動で入れ替わり、離した位置で盤面が確定します。',
-      '同じ色を3つ以上そろえると珠が消えて得点。連鎖でボーナスアップ！'
-    ],
-    statsLabels: {
-      turns: '残りターン',
-      score: 'スコア',
-      combos: '合計コンボ'
-    },
-    lastComboTitle: '今回のコンボ',
-    noCombosYet: 'まだコンボはありません。',
-    resetButton: 'リセットして再挑戦',
-    messageInvalidSwap: 'コンボができなかったので元に戻しました。',
-    messageCombo: comboCount => `${comboCount}コンボ！`,
-    messageReady: '珠をドラッグして並べ替えてください。',
-    outOfTurns: 'ターンが尽きました。リセットして続けましょう。',
-    elementNames: {
-      fire: '火',
-      water: '水',
-      wood: '木',
-      light: '光',
-      dark: '闇',
-      heart: '回復'
-    },
-    comboLineTemplate: 'コンボ{index}: {element} ×{count} (+{points}{unit}) / {cascade}',
-    pointsUnit: '点',
-    cascadeLabelTemplate: '{value}連鎖目'
-  },
-  en: {
-    languageName: 'English',
-    gameTitle: 'Math Puzzle Dungeon',
-    subtitle: 'Drag elemental orbs to new positions and rack up points!',
-    languageSelectLabel: 'Language',
-    instructionsTitle: 'How to Play',
-    instructions: [
-      'Press and hold an orb, then drag your finger across neighboring tiles.',
-      'Each tile you pass over swaps automatically and locks when you release.',
-      'Match three or more of the same element to clear them and earn cascading bonuses.'
-    ],
-    statsLabels: {
-      turns: 'Turns left',
-      score: 'Score',
-      combos: 'Total combos'
-    },
-    lastComboTitle: 'Latest combo chain',
-    noCombosYet: 'No combos yet—make a move!',
-    resetButton: 'Start a new run',
-    messageInvalidSwap: 'No combo formed—board reset.',
-    messageCombo: comboCount => (comboCount === 1 ? 'Nice combo!' : `${comboCount} combos!`),
-    messageReady: 'Drag across adjacent orbs to reposition them.',
-    outOfTurns: 'You are out of turns. Reset to keep playing.',
-    elementNames: {
-      fire: 'Fire',
-      water: 'Water',
-      wood: 'Wood',
-      light: 'Light',
-      dark: 'Dark',
-      heart: 'Heart'
-    },
-    comboLineTemplate: 'Combo {index}: {element} ×{count} (+{points}{unit}) • {cascade}',
-    pointsUnit: 'pts',
-    cascadeLabelTemplate: 'Cascade {value}'
-  },
-  es: {
-    languageName: 'Español',
-    gameTitle: 'Mazmorra de Números',
-    subtitle: 'Arrastra esferas elementales para lograr combos y sumar puntos.',
-    languageSelectLabel: 'Idioma',
-    instructionsTitle: 'Cómo jugar',
-    instructions: [
-      'Mantén pulsada una esfera y arrástrala por las casillas vecinas.',
-      'Cada casilla que atraviesas se intercambia automáticamente hasta soltar el dedo.',
-      'Forma tres o más del mismo color para eliminarlas y consigue bonificaciones por cadena.'
-    ],
-    statsLabels: {
-      turns: 'Turnos restantes',
-      score: 'Puntuación',
-      combos: 'Combos totales'
-    },
-    lastComboTitle: 'Combo reciente',
-    noCombosYet: 'Todavía no hay combos.',
-    resetButton: 'Reiniciar partida',
-    messageInvalidSwap: 'No se formó ningún combo; tablero restaurado.',
-    messageCombo: comboCount => (comboCount === 1 ? '¡Buen combo!' : `¡${comboCount} combos!`),
-    messageReady: 'Arrastra por las esferas vecinas para reordenarlas.',
-    outOfTurns: 'No quedan turnos. Reinicia para seguir jugando.',
-    elementNames: {
-      fire: 'Fuego',
-      water: 'Agua',
-      wood: 'Bosque',
-      light: 'Luz',
-      dark: 'Oscuridad',
-      heart: 'Corazón'
-    },
-    comboLineTemplate: 'Combo {index}: {element} ×{count} (+{points}{unit}) • {cascade}',
-    pointsUnit: 'pts',
-    cascadeLabelTemplate: 'Cadena {value}'
-  }
-};
-
-type Locale = keyof typeof TRANSLATIONS;
-
-const NUMBER_LOCALES: Record<Locale, string> = {
-  ja: 'ja-JP',
-  en: 'en-US',
-  es: 'es-ES'
-};
-
-type MatchGroup = {
-  cells: CellPosition[];
-  type: ElementType;
-};
-
-type MatchResult = {
-  matchMask: boolean[][];
-  groups: MatchGroup[];
-};
-
-type ResolutionResult = {
-  board: ElementType[][];
-  combos: ComboDetail[];
-  scoreGain: number;
-};
-
-type DragSession = {
-  active: boolean;
-  pointerId: number | null;
-  origin: CellPosition | null;
-  lastCell: CellPosition | null;
-  snapshot: ElementType[][] | null;
-  latestBoard: ElementType[][] | null;
-  moved: boolean;
-};
-
-const createEmptyDragSession = (): DragSession => ({
-  active: false,
-  pointerId: null,
-  origin: null,
-  lastCell: null,
-  snapshot: null,
-  latestBoard: null,
-  moved: false
-});
-
-const randomOrb = (): ElementType =>
-  GEM_TYPES[Math.floor(Math.random() * GEM_TYPES.length)];
-
-const sameOrb = (
-  board: (ElementType | null)[][],
-  row: number,
-  col: number,
-  orb: ElementType
-) => board[row] && board[row][col] === orb;
-
-const wouldCreateMatch = (
-  board: (ElementType | null)[][],
-  row: number,
-  col: number,
-  orb: ElementType
-) => {
-  if (
-    (sameOrb(board, row, col - 1, orb) && sameOrb(board, row, col - 2, orb)) ||
-    (sameOrb(board, row, col + 1, orb) && sameOrb(board, row, col + 2, orb)) ||
-    (sameOrb(board, row, col - 1, orb) && sameOrb(board, row, col + 1, orb))
-  ) {
-    return true;
-  }
-  if (
-    (sameOrb(board, row - 1, col, orb) && sameOrb(board, row - 2, col, orb)) ||
-    (sameOrb(board, row + 1, col, orb) && sameOrb(board, row + 2, col, orb)) ||
-    (sameOrb(board, row - 1, col, orb) && sameOrb(board, row + 1, col, orb))
-  ) {
-    return true;
-  }
-  return false;
-};
-
-const generateOrb = (
-  board: (ElementType | null)[][],
-  row: number,
-  col: number
-): ElementType => {
-  let orb = randomOrb();
-  let safety = 0;
-  while (wouldCreateMatch(board, row, col, orb) && safety < 25) {
-    orb = randomOrb();
-    safety += 1;
-  }
-  return orb;
-};
-
-const createInitialBoard = (): ElementType[][] => {
-  const template: (ElementType | null)[][] = Array.from({ length: BOARD_ROWS }, () =>
-    Array<ElementType | null>(BOARD_COLS).fill(null)
-  );
-  for (let row = 0; row < BOARD_ROWS; row += 1) {
-    for (let col = 0; col < BOARD_COLS; col += 1) {
-      template[row][col] = generateOrb(template, row, col);
-    }
-  }
-  return template.map(row => row.map(cell => cell ?? randomOrb()));
-};
-
-const swapCells = (
-  board: ElementType[][],
-  a: CellPosition,
-  b: CellPosition
-): ElementType[][] => {
-  const clone = board.map(r => [...r]);
-  const temp = clone[a.row][a.col];
-  clone[a.row][a.col] = clone[b.row][b.col];
-  clone[b.row][b.col] = temp;
-  return clone;
-};
-
-const findMatches = (board: ElementType[][]): MatchResult => {
-  const matchMask = Array.from({ length: BOARD_ROWS }, () =>
-    Array<boolean>(BOARD_COLS).fill(false)
-  );
-
-  for (let row = 0; row < BOARD_ROWS; row += 1) {
-    let col = 0;
-    while (col < BOARD_COLS) {
-      const orb = board[row][col];
-      let runLength = 1;
-      while (col + runLength < BOARD_COLS && board[row][col + runLength] === orb) {
-        runLength += 1;
-      }
-      if (orb && runLength >= 3) {
-        for (let offset = 0; offset < runLength; offset += 1) {
-          matchMask[row][col + offset] = true;
-        }
-      }
-      col += runLength;
-    }
-  }
-
-  for (let col = 0; col < BOARD_COLS; col += 1) {
-    let row = 0;
-    while (row < BOARD_ROWS) {
-      const orb = board[row][col];
-      let runLength = 1;
-      while (row + runLength < BOARD_ROWS && board[row + runLength][col] === orb) {
-        runLength += 1;
-      }
-      if (orb && runLength >= 3) {
-        for (let offset = 0; offset < runLength; offset += 1) {
-          matchMask[row + offset][col] = true;
-        }
-      }
-      row += runLength;
-    }
-  }
-
-  const visited = Array.from({ length: BOARD_ROWS }, () =>
-    Array<boolean>(BOARD_COLS).fill(false)
-  );
-  const groups: MatchGroup[] = [];
-
-  for (let row = 0; row < BOARD_ROWS; row += 1) {
-    for (let col = 0; col < BOARD_COLS; col += 1) {
-      if (!matchMask[row][col] || visited[row][col]) {
-        continue;
-      }
-      const target = board[row][col];
-      const cells: CellPosition[] = [];
-      const queue: CellPosition[] = [{ row, col }];
-      visited[row][col] = true;
-      let pointer = 0;
-
-      while (pointer < queue.length) {
-        const current = queue[pointer];
-        pointer += 1;
-        cells.push(current);
-
-        const offsets = [
-          { row: current.row - 1, col: current.col },
-          { row: current.row + 1, col: current.col },
-          { row: current.row, col: current.col - 1 },
-          { row: current.row, col: current.col + 1 }
-        ];
-
-        for (const next of offsets) {
-          if (
-            next.row < 0 ||
-            next.row >= BOARD_ROWS ||
-            next.col < 0 ||
-            next.col >= BOARD_COLS
-          ) {
-            continue;
-          }
-          if (visited[next.row][next.col]) {
-            continue;
-          }
-          if (!matchMask[next.row][next.col]) {
-            continue;
-          }
-          if (board[next.row][next.col] !== target) {
-            continue;
-          }
-          visited[next.row][next.col] = true;
-          queue.push(next);
-        }
-      }
-
-      if (target) {
-        groups.push({ cells, type: target });
-      }
-    }
-  }
-
-  return { matchMask, groups };
-};
-
-const resolveBoard = (board: ElementType[][]): ResolutionResult => {
-  const working: (ElementType | null)[][] = board.map(row => [...row]);
-  const combos: ComboDetail[] = [];
-  let scoreGain = 0;
-  let cascade = 0;
-
-  while (true) {
-    const { matchMask, groups } = findMatches(working as ElementType[][]);
-    if (groups.length === 0) {
-      break;
-    }
-
-    cascade += 1;
-    const cascadeMultiplier = 1 + (cascade - 1) * 0.25;
-
-    for (const group of groups) {
-      const size = group.cells.length;
-      const basePoints = 50 + size * 20;
-      const points = Math.round(basePoints * cascadeMultiplier);
-      scoreGain += points;
-      combos.push({
-        type: group.type,
-        size,
-        points,
-        cascade
-      });
-    }
-
-    for (let row = 0; row < BOARD_ROWS; row += 1) {
-      for (let col = 0; col < BOARD_COLS; col += 1) {
-        if (matchMask[row][col]) {
-          working[row][col] = null;
-        }
-      }
-    }
-
-    for (let col = 0; col < BOARD_COLS; col += 1) {
-      let writeRow = BOARD_ROWS - 1;
-      for (let row = BOARD_ROWS - 1; row >= 0; row -= 1) {
-        const cell = working[row][col];
-        if (cell !== null) {
-          working[writeRow][col] = cell;
-          if (writeRow !== row) {
-            working[row][col] = null;
-          }
-          writeRow -= 1;
-        }
-      }
-      for (let fillRow = writeRow; fillRow >= 0; fillRow -= 1) {
-        working[fillRow][col] = generateOrb(working, fillRow, col);
-      }
-    }
-  }
-
-  const finalBoard: ElementType[][] = working.map(row =>
-    row.map(cell => cell ?? randomOrb())
-  );
-
-  return { board: finalBoard, combos, scoreGain };
-};
+const languageOptions = (Object.keys(TRANSLATIONS) as Locale[]).map(locale => ({
+  value: locale,
+  label: TRANSLATIONS[locale].languageName
+}));
 
 const App = () => {
   const [language, setLanguage] = useState<Locale>('ja');
+  const [practiceMode, setPracticeMode] = useState(true);
   const t = useMemo(() => TRANSLATIONS[language], [language]);
   const numberFormatter = useMemo(
     () => new Intl.NumberFormat(NUMBER_LOCALES[language]),
     [language]
   );
-  const [board, setBoard] = useState<ElementType[][]>(() => createInitialBoard());
-  const boardStateRef = useRef(board);
-  useEffect(() => {
-    boardStateRef.current = board;
-  }, [board]);
 
-  const [selected, setSelected] = useState<CellPosition | null>(null);
-  const [score, setScore] = useState(0);
-  const [turns, setTurns] = useState(MAX_TURNS);
-  const turnsRef = useRef(turns);
-  useEffect(() => {
-    turnsRef.current = turns;
-  }, [turns]);
-  const [totalCombos, setTotalCombos] = useState(0);
-  const [lastCombos, setLastCombos] = useState<ComboDetail[]>([]);
-  const [message, setMessage] = useState('');
+  const turnLimit = practiceMode ? null : MAX_TURNS;
+  const {
+    board,
+    selected,
+    score,
+    turns,
+    totalCombos,
+    lastCombos,
+    message,
+    setMessage,
+    handleReset,
+    handlePointerDown
+  } = useGameEngine(t, turnLimit);
 
   useEffect(() => {
     setMessage(t.messageReady);
-  }, [t]);
+  }, [t, setMessage]);
 
-  const dragSessionRef = useRef<DragSession>(createEmptyDragSession());
-  const moveListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
-  const upListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
-  const cancelListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
+  useEffect(() => {
+    handleReset();
+  }, [practiceMode, handleReset]);
 
-  const cleanupGlobalListeners = () => {
-    if (moveListenerRef.current) {
-      window.removeEventListener('pointermove', moveListenerRef.current);
-      moveListenerRef.current = null;
-    }
-    if (upListenerRef.current) {
-      window.removeEventListener('pointerup', upListenerRef.current);
-      upListenerRef.current = null;
-    }
-    if (cancelListenerRef.current) {
-      window.removeEventListener('pointercancel', cancelListenerRef.current);
-      cancelListenerRef.current = null;
-    }
-  };
-
-  const resetDragSession = () => {
-    dragSessionRef.current = createEmptyDragSession();
-  };
-
-  useEffect(() => () => {
-    cleanupGlobalListeners();
-  }, []);
-
-  const handleReset = () => {
-    cleanupGlobalListeners();
-    resetDragSession();
-    const freshBoard = createInitialBoard();
-    setBoard(freshBoard);
-    boardStateRef.current = freshBoard;
-    setSelected(null);
-    setScore(0);
-    setTurns(MAX_TURNS);
-    turnsRef.current = MAX_TURNS;
-    setTotalCombos(0);
-    setLastCombos([]);
-    setMessage(t.messageReady);
-  };
-
-  const handlePointerDown = (
-    event: ReactPointerEvent<HTMLButtonElement>,
-    row: number,
-    col: number
-  ) => {
-    if (turnsRef.current <= 0) {
-      setMessage(t.outOfTurns);
-      setSelected(null);
-      return;
-    }
-
-    event.preventDefault();
-    cleanupGlobalListeners();
-
-    const snapshot = boardStateRef.current.map(r => [...r]);
-
-    dragSessionRef.current = {
-      active: true,
-      pointerId: event.pointerId,
-      origin: { row, col },
-      lastCell: { row, col },
-      snapshot,
-      latestBoard: snapshot.map(r => [...r]),
-      moved: false
-    };
-
-    setSelected({ row, col });
-    setMessage(t.messageReady);
-
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const session = dragSessionRef.current;
-      if (!session.active || moveEvent.pointerId !== session.pointerId) {
-        return;
-      }
-      moveEvent.preventDefault();
-      const target = document.elementFromPoint(moveEvent.clientX, moveEvent.clientY) as
-        | HTMLElement
-        | null;
-      if (!target) {
-        return;
-      }
-      const rowAttr = target.getAttribute('data-row');
-      const colAttr = target.getAttribute('data-col');
-      if (rowAttr === null || colAttr === null) {
-        return;
-      }
-      const nextCell = { row: Number(rowAttr), col: Number(colAttr) };
-      const last = session.lastCell;
-      if (!last) {
-        return;
-      }
-      if (nextCell.row === last.row && nextCell.col === last.col) {
-        return;
-      }
-      const distance =
-        Math.abs(last.row - nextCell.row) + Math.abs(last.col - nextCell.col);
-      if (distance !== 1) {
-        return;
-      }
-
-      setBoard(prevBoard => {
-        const nextBoard = swapCells(prevBoard, last, nextCell);
-        const activeSession = dragSessionRef.current;
-        activeSession.lastCell = nextCell;
-        activeSession.latestBoard = nextBoard;
-        activeSession.moved = true;
-        boardStateRef.current = nextBoard;
-        return nextBoard;
-      });
-      setSelected(nextCell);
-    };
-
-    const finalizeDrag = (releaseEvent: PointerEvent) => {
-      const session = dragSessionRef.current;
-      if (!session.active || releaseEvent.pointerId !== session.pointerId) {
-        return;
-      }
-      releaseEvent.preventDefault();
-      cleanupGlobalListeners();
-
-      const snapshotBoard = session.snapshot ?? boardStateRef.current.map(r => [...r]);
-      const boardToResolve = session.latestBoard ?? snapshotBoard;
-
-      if (!session.moved) {
-        const revertBoard = snapshotBoard.map(r => [...r]);
-        setBoard(revertBoard);
-        boardStateRef.current = revertBoard;
-        setSelected(null);
-        resetDragSession();
-        setMessage(t.messageReady);
-        return;
-      }
-
-      const result = resolveBoard(boardToResolve);
-
-      if (result.combos.length === 0) {
-        const revertBoard = snapshotBoard.map(r => [...r]);
-        setBoard(revertBoard);
-        boardStateRef.current = revertBoard;
-        setSelected(null);
-        setLastCombos([]);
-        resetDragSession();
-        setMessage(t.messageInvalidSwap);
-        return;
-      }
-
-      setBoard(result.board);
-      boardStateRef.current = result.board;
-      setScore(prev => prev + result.scoreGain);
-      setTotalCombos(prev => prev + result.combos.length);
-      setLastCombos(result.combos);
-      setTurns(prev => {
-        const updated = Math.max(0, prev - 1);
-        turnsRef.current = updated;
-        setMessage(updated === 0 ? t.outOfTurns : t.messageCombo(result.combos.length));
-        return updated;
-      });
-      setSelected(null);
-      resetDragSession();
-    };
-
-    const cancelDrag = (cancelEvent: PointerEvent) => {
-      const session = dragSessionRef.current;
-      if (!session.active || cancelEvent.pointerId !== session.pointerId) {
-        return;
-      }
-      cleanupGlobalListeners();
-      const revertBoard = (session.snapshot ?? boardStateRef.current).map(r => [...r]);
-      setBoard(revertBoard);
-      boardStateRef.current = revertBoard;
-      setSelected(null);
-      resetDragSession();
-      setMessage(t.messageReady);
-    };
-
-    moveListenerRef.current = handlePointerMove;
-    upListenerRef.current = finalizeDrag;
-    cancelListenerRef.current = cancelDrag;
-
-    window.addEventListener('pointermove', handlePointerMove, { passive: false });
-    window.addEventListener('pointerup', finalizeDrag);
-    window.addEventListener('pointercancel', cancelDrag);
-  };
-
-  const formattedTurns = numberFormatter.format(turns);
+  const formattedTurns = practiceMode
+    ? '∞'
+    : numberFormatter.format(Math.max(0, Math.floor(turns)));
   const formattedScore = numberFormatter.format(score);
   const formattedComboTotal = numberFormatter.format(totalCombos);
+  const isOutOfTurns = turnLimit !== null && turns <= 0;
+
+  const togglePractice = () => setPracticeMode(prev => !prev);
 
   return (
     <div className="game-shell">
       <div className="game-card">
-        <header className="game-header">
-          <div>
-            <h1>{t.gameTitle}</h1>
-            <p>{t.subtitle}</p>
-          </div>
-          <label className="language-select">
-            <span>{t.languageSelectLabel}</span>
-            <select
-              value={language}
-              onChange={event => setLanguage(event.target.value as Locale)}
-            >
-              {Object.keys(TRANSLATIONS).map(locale => (
-                <option key={locale} value={locale}>
-                  {TRANSLATIONS[locale as Locale].languageName}
-                </option>
-              ))}
-            </select>
-          </label>
-        </header>
+        <TopBar
+          language={language}
+          languageOptions={languageOptions}
+          onLanguageChange={value => setLanguage(value)}
+          practiceMode={practiceMode}
+          onTogglePractice={togglePractice}
+          t={t}
+        />
 
-        <section className="scoreboard">
-          <div className="stat-card">
-            <span className="stat-label">{t.statsLabels.turns}</span>
-            <span className="stat-value">{formattedTurns}</span>
-          </div>
-          <div className="stat-card">
-            <span className="stat-label">{t.statsLabels.score}</span>
-            <span className="stat-value">
-              {formattedScore} {t.pointsUnit}
-            </span>
-          </div>
-          <div className="stat-card">
-            <span className="stat-label">{t.statsLabels.combos}</span>
-            <span className="stat-value">{formattedComboTotal}</span>
-          </div>
-        </section>
+        <StatsPanel
+          t={t}
+          turnsLabel={formattedTurns}
+          scoreLabel={`${formattedScore} ${t.pointsUnit}`}
+          comboLabel={formattedComboTotal}
+        />
+
+        <QuestTracker t={t} totalCombos={totalCombos} />
 
         <div className="game-body">
-          <div className="board-area">
-            <div className="board" role="grid" aria-label="Puzzle board">
-              {board.map((row, rowIndex) =>
-                row.map((cell, colIndex) => {
-                  const isSelected =
-                    selected?.row === rowIndex && selected?.col === colIndex;
-                  const classList = ['orb', cell];
-                  if (isSelected) {
-                    classList.push('selected');
-                  }
-                  return (
-                    <button
-                      key={`${rowIndex}-${colIndex}`}
-                      type="button"
-                      className={classList.join(' ')}
-                      data-row={rowIndex}
-                      data-col={colIndex}
-                      onPointerDown={event => handlePointerDown(event, rowIndex, colIndex)}
-                      onContextMenu={event => event.preventDefault()}
-                      aria-label={`${t.elementNames[cell]} orb`}
-                    >
-                      <span className="orb-emoji">{ORB_EMOJI[cell]}</span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-
-            <div className="legend">
-              {GEM_TYPES.map(type => (
-                <span key={type} className={`legend-pill ${type}`}>
-                  <span className="legend-emoji">{ORB_EMOJI[type]}</span>
-                  <span className="legend-text">
-                    {t.elementNames[type]}
-                  </span>
-                </span>
-              ))}
-            </div>
-
-            <p className="status-message">{message}</p>
-
-            <button className="reset-button" type="button" onClick={handleReset}>
-              {t.resetButton}
-            </button>
-          </div>
+          <Board
+            board={board}
+            selected={selected}
+            onPointerDown={handlePointerDown}
+            t={t}
+            onReset={handleReset}
+            message={isOutOfTurns ? t.outOfTurns : message}
+            isOutOfTurns={isOutOfTurns}
+          />
 
           <aside className="sidebar">
-            <section className="instructions">
-              <h2>{t.instructionsTitle}</h2>
-              <ol>
-                {t.instructions.map((step, index) => (
-                  <li key={index}>{step}</li>
-                ))}
-              </ol>
-            </section>
-
-            <section className="combo-log">
-              <h2>{t.lastComboTitle}</h2>
-              {lastCombos.length === 0 ? (
-                <p className="muted">{t.noCombosYet}</p>
-              ) : (
-                <ul>
-                  {lastCombos.map((combo, index) => {
-                    const cascadeLabel = format(t.cascadeLabelTemplate, {
-                      value: numberFormatter.format(combo.cascade)
-                    });
-                    const line = format(t.comboLineTemplate, {
-                      index: index + 1,
-                      element: t.elementNames[combo.type],
-                      count: numberFormatter.format(combo.size),
-                      points: numberFormatter.format(combo.points),
-                      unit: t.pointsUnit,
-                      cascade: cascadeLabel
-                    });
-                    return <li key={`${combo.type}-${index}`}>{line}</li>;
-                  })}
-                </ul>
-              )}
-            </section>
+            <Instructions t={t} />
+            <ComboLog t={t} combos={lastCombos} formatNumber={value => numberFormatter.format(value)} />
           </aside>
         </div>
       </div>

--- a/math-dungeon-app/src/components/Board.tsx
+++ b/math-dungeon-app/src/components/Board.tsx
@@ -1,0 +1,70 @@
+import { ORB_EMOJI } from '../gameConfig';
+import type { CellPosition, ElementType, Translation } from '../types';
+
+interface Props {
+  board: ElementType[][];
+  selected: CellPosition | null;
+  onPointerDown: (
+    event: React.PointerEvent<HTMLButtonElement>,
+    row: number,
+    col: number
+  ) => void;
+  t: Translation;
+  onReset: () => void;
+  message: string;
+  isOutOfTurns: boolean;
+}
+
+export const Board = ({
+  board,
+  selected,
+  onPointerDown,
+  t,
+  onReset,
+  message,
+  isOutOfTurns
+}: Props) => (
+  <div className="board-area">
+    <div className="board" role="grid" aria-label="Puzzle board">
+      {board.map((row, rowIndex) =>
+        row.map((cell, colIndex) => {
+          const isSelected = selected?.row === rowIndex && selected?.col === colIndex;
+          const classList = ['orb', cell];
+          if (isSelected) {
+            classList.push('selected');
+          }
+          return (
+            <button
+              key={`${rowIndex}-${colIndex}`}
+              type="button"
+              className={classList.join(' ')}
+              data-row={rowIndex}
+              data-col={colIndex}
+              onPointerDown={event => onPointerDown(event, rowIndex, colIndex)}
+              onContextMenu={event => event.preventDefault()}
+              aria-label={`${t.elementNames[cell]} orb`}
+              disabled={isOutOfTurns}
+            >
+              <span className="orb-emoji">{ORB_EMOJI[cell]}</span>
+            </button>
+          );
+        })
+      )}
+    </div>
+
+    <div className="legend">
+      {Object.entries(ORB_EMOJI).map(([type, emoji]) => (
+        <span key={type} className={`legend-pill ${type}`}>
+          <span className="legend-emoji">{emoji}</span>
+          <span className="legend-text">{t.elementNames[type as ElementType]}</span>
+        </span>
+      ))}
+    </div>
+
+    <p className="status-message">{message}</p>
+
+    <button className="reset-button" type="button" onClick={onReset}>
+      {t.resetButton}
+    </button>
+  </div>
+);

--- a/math-dungeon-app/src/components/ComboLog.tsx
+++ b/math-dungeon-app/src/components/ComboLog.tsx
@@ -1,0 +1,34 @@
+import type { Translation, ComboDetail } from '../types';
+import { formatTemplate } from '../utils/format';
+
+interface Props {
+  t: Translation;
+  combos: ComboDetail[];
+  formatNumber: (value: number) => string;
+}
+
+export const ComboLog = ({ t, combos, formatNumber }: Props) => (
+  <section className="panel combo-log">
+    <h2>{t.lastComboTitle}</h2>
+    {combos.length === 0 ? (
+      <p className="muted">{t.noCombosYet}</p>
+    ) : (
+      <ul>
+        {combos.map((combo, index) => {
+          const cascadeLabel = formatTemplate(t.cascadeLabelTemplate, {
+            value: formatNumber(combo.cascade)
+          });
+          const line = formatTemplate(t.comboLineTemplate, {
+            index: index + 1,
+            element: t.elementNames[combo.type],
+            count: formatNumber(combo.size),
+            points: formatNumber(combo.points),
+            unit: t.pointsUnit,
+            cascade: cascadeLabel
+          });
+          return <li key={`${combo.type}-${index}`}>{line}</li>;
+        })}
+      </ul>
+    )}
+  </section>
+);

--- a/math-dungeon-app/src/components/Instructions.tsx
+++ b/math-dungeon-app/src/components/Instructions.tsx
@@ -1,0 +1,16 @@
+import type { Translation } from '../types';
+
+interface Props {
+  t: Translation;
+}
+
+export const Instructions = ({ t }: Props) => (
+  <section className="panel instructions">
+    <h2>{t.instructionsTitle}</h2>
+    <ol>
+      {t.instructions.map((step, index) => (
+        <li key={index}>{step}</li>
+      ))}
+    </ol>
+  </section>
+);

--- a/math-dungeon-app/src/components/QuestTracker.tsx
+++ b/math-dungeon-app/src/components/QuestTracker.tsx
@@ -1,0 +1,45 @@
+import type { Translation } from '../types';
+import { formatTemplate } from '../utils/format';
+
+interface Props {
+  t: Translation;
+  totalCombos: number;
+}
+
+const BADGE_STEPS = [
+  { label: '✨', combos: 3 },
+  { label: '☀️', combos: 8 },
+  { label: '🏆', combos: 15 }
+];
+
+export const QuestTracker = ({ t, totalCombos }: Props) => {
+  const nextStep = BADGE_STEPS.find(step => totalCombos < step.combos);
+  const progressPercent = Math.min(100, Math.round((totalCombos / BADGE_STEPS[BADGE_STEPS.length - 1].combos) * 100));
+  const nextLabel = nextStep
+    ? formatTemplate(t.questLabel, { value: Math.max(0, nextStep.combos - totalCombos) })
+    : t.questComplete;
+
+  return (
+    <section className="quest-card">
+      <div className="quest-head">
+        <div>
+          <p className="eyebrow">{t.moodLabel}</p>
+          <h2>{t.adventureTitle}</h2>
+          <p className="muted">{t.adventureDescription}</p>
+        </div>
+        <div className="badges">
+          {BADGE_STEPS.map(step => (
+            <span key={step.combos} className={`badge ${totalCombos >= step.combos ? 'active' : ''}`}>
+              {step.label}
+              <span className="badge-count">×{step.combos}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="quest-progress">
+        <div className="quest-progress-bar" style={{ width: `${progressPercent}%` }} />
+      </div>
+      <p className="quest-next">{nextLabel}</p>
+    </section>
+  );
+};

--- a/math-dungeon-app/src/components/StatsPanel.tsx
+++ b/math-dungeon-app/src/components/StatsPanel.tsx
@@ -1,0 +1,25 @@
+import type { Translation } from '../types';
+
+interface Props {
+  t: Translation;
+  turnsLabel: string;
+  scoreLabel: string;
+  comboLabel: string;
+}
+
+export const StatsPanel = ({ t, turnsLabel, scoreLabel, comboLabel }: Props) => (
+  <section className="scoreboard">
+    <div className="stat-card">
+      <span className="stat-label">{t.statsLabels.turns}</span>
+      <span className="stat-value soft">{turnsLabel}</span>
+    </div>
+    <div className="stat-card">
+      <span className="stat-label">{t.statsLabels.score}</span>
+      <span className="stat-value highlight">{scoreLabel}</span>
+    </div>
+    <div className="stat-card">
+      <span className="stat-label">{t.statsLabels.combos}</span>
+      <span className="stat-value soft">{comboLabel}</span>
+    </div>
+  </section>
+);

--- a/math-dungeon-app/src/components/TopBar.tsx
+++ b/math-dungeon-app/src/components/TopBar.tsx
@@ -1,0 +1,43 @@
+import type { Locale, Translation } from '../types';
+
+type Props = {
+  language: Locale;
+  languageOptions: { value: Locale; label: string }[];
+  onLanguageChange: (value: Locale) => void;
+  t: Translation;
+  practiceMode: boolean;
+  onTogglePractice: () => void;
+};
+
+export const TopBar = ({
+  language,
+  languageOptions,
+  onLanguageChange,
+  t,
+  practiceMode,
+  onTogglePractice
+}: Props) => (
+  <header className="game-header">
+    <div>
+      <p className="eyebrow">{t.adventureTitle}</p>
+      <h1>{t.gameTitle}</h1>
+      <p>{t.subtitle}</p>
+    </div>
+    <div className="top-actions">
+      <label className="language-select">
+        <span>{t.languageSelectLabel}</span>
+        <select value={language} onChange={event => onLanguageChange(event.target.value as Locale)}>
+          {languageOptions.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button className="pill-button" type="button" onClick={onTogglePractice}>
+        <span className="pill-label">{t.practiceModeLabel}</span>
+        <span className="pill-value">{practiceMode ? t.practiceModeOn : t.practiceModeOff}</span>
+      </button>
+    </div>
+  </header>
+);

--- a/math-dungeon-app/src/gameConfig.ts
+++ b/math-dungeon-app/src/gameConfig.ts
@@ -1,0 +1,22 @@
+import type { ElementType, Locale } from './types';
+
+export const BOARD_ROWS = 5;
+export const BOARD_COLS = 6;
+export const MAX_TURNS = 20;
+
+export const GEM_TYPES: ElementType[] = ['fire', 'water', 'wood', 'light', 'dark', 'heart'];
+
+export const ORB_EMOJI: Record<ElementType, string> = {
+  fire: '🔥',
+  water: '💧',
+  wood: '🌿',
+  light: '✨',
+  dark: '🌙',
+  heart: '💖'
+};
+
+export const NUMBER_LOCALES: Record<Locale, string> = {
+  ja: 'ja-JP',
+  en: 'en-US',
+  es: 'es-ES'
+};

--- a/math-dungeon-app/src/hooks/useGameEngine.ts
+++ b/math-dungeon-app/src/hooks/useGameEngine.ts
@@ -1,0 +1,455 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { BOARD_COLS, BOARD_ROWS, GEM_TYPES, MAX_TURNS } from '../gameConfig';
+import type { CellPosition, ComboDetail, ElementType, Translation } from '../types';
+
+const randomOrb = (): ElementType =>
+  GEM_TYPES[Math.floor(Math.random() * GEM_TYPES.length)];
+
+const sameOrb = (
+  board: (ElementType | null)[][],
+  row: number,
+  col: number,
+  orb: ElementType
+) => board[row] && board[row][col] === orb;
+
+const wouldCreateMatch = (
+  board: (ElementType | null)[][],
+  row: number,
+  col: number,
+  orb: ElementType
+) => {
+  if (
+    (sameOrb(board, row, col - 1, orb) && sameOrb(board, row, col - 2, orb)) ||
+    (sameOrb(board, row, col + 1, orb) && sameOrb(board, row, col + 2, orb)) ||
+    (sameOrb(board, row, col - 1, orb) && sameOrb(board, row, col + 1, orb))
+  ) {
+    return true;
+  }
+  if (
+    (sameOrb(board, row - 1, col, orb) && sameOrb(board, row - 2, col, orb)) ||
+    (sameOrb(board, row + 1, col, orb) && sameOrb(board, row + 2, col, orb)) ||
+    (sameOrb(board, row - 1, col, orb) && sameOrb(board, row + 1, col, orb))
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const generateOrb = (
+  board: (ElementType | null)[][],
+  row: number,
+  col: number
+): ElementType => {
+  let orb = randomOrb();
+  let safety = 0;
+  while (wouldCreateMatch(board, row, col, orb) && safety < 25) {
+    orb = randomOrb();
+    safety += 1;
+  }
+  return orb;
+};
+
+const createInitialBoard = (): ElementType[][] => {
+  const template: (ElementType | null)[][] = Array.from({ length: BOARD_ROWS }, () =>
+    Array<ElementType | null>(BOARD_COLS).fill(null)
+  );
+  for (let row = 0; row < BOARD_ROWS; row += 1) {
+    for (let col = 0; col < BOARD_COLS; col += 1) {
+      template[row][col] = generateOrb(template, row, col);
+    }
+  }
+  return template.map(row => row.map(cell => cell ?? randomOrb()));
+};
+
+const swapCells = (
+  board: ElementType[][],
+  a: CellPosition,
+  b: CellPosition
+): ElementType[][] => {
+  const clone = board.map(r => [...r]);
+  const temp = clone[a.row][a.col];
+  clone[a.row][a.col] = clone[b.row][b.col];
+  clone[b.row][b.col] = temp;
+  return clone;
+};
+
+const findMatches = (board: ElementType[][]) => {
+  const matchMask = Array.from({ length: BOARD_ROWS }, () =>
+    Array<boolean>(BOARD_COLS).fill(false)
+  );
+
+  for (let row = 0; row < BOARD_ROWS; row += 1) {
+    let col = 0;
+    while (col < BOARD_COLS) {
+      const orb = board[row][col];
+      let runLength = 1;
+      while (col + runLength < BOARD_COLS && board[row][col + runLength] === orb) {
+        runLength += 1;
+      }
+      if (orb && runLength >= 3) {
+        for (let offset = 0; offset < runLength; offset += 1) {
+          matchMask[row][col + offset] = true;
+        }
+      }
+      col += runLength;
+    }
+  }
+
+  for (let col = 0; col < BOARD_COLS; col += 1) {
+    let row = 0;
+    while (row < BOARD_ROWS) {
+      const orb = board[row][col];
+      let runLength = 1;
+      while (row + runLength < BOARD_ROWS && board[row + runLength][col] === orb) {
+        runLength += 1;
+      }
+      if (orb && runLength >= 3) {
+        for (let offset = 0; offset < runLength; offset += 1) {
+          matchMask[row + offset][col] = true;
+        }
+      }
+      row += runLength;
+    }
+  }
+
+  const visited = Array.from({ length: BOARD_ROWS }, () =>
+    Array<boolean>(BOARD_COLS).fill(false)
+  );
+  const groups: { cells: CellPosition[]; type: ElementType }[] = [];
+
+  for (let row = 0; row < BOARD_ROWS; row += 1) {
+    for (let col = 0; col < BOARD_COLS; col += 1) {
+      if (!matchMask[row][col] || visited[row][col]) {
+        continue;
+      }
+      const target = board[row][col];
+      const cells: CellPosition[] = [];
+      const queue: CellPosition[] = [{ row, col }];
+      visited[row][col] = true;
+      let pointer = 0;
+
+      while (pointer < queue.length) {
+        const current = queue[pointer];
+        pointer += 1;
+        cells.push(current);
+
+        const offsets = [
+          { row: current.row - 1, col: current.col },
+          { row: current.row + 1, col: current.col },
+          { row: current.row, col: current.col - 1 },
+          { row: current.row, col: current.col + 1 }
+        ];
+
+        for (const next of offsets) {
+          if (
+            next.row < 0 ||
+            next.row >= BOARD_ROWS ||
+            next.col < 0 ||
+            next.col >= BOARD_COLS
+          ) {
+            continue;
+          }
+          if (visited[next.row][next.col]) {
+            continue;
+          }
+          if (!matchMask[next.row][next.col]) {
+            continue;
+          }
+          if (board[next.row][next.col] !== target) {
+            continue;
+          }
+          visited[next.row][next.col] = true;
+          queue.push(next);
+        }
+      }
+
+      if (target) {
+        groups.push({ cells, type: target });
+      }
+    }
+  }
+
+  return { matchMask, groups };
+};
+
+const resolveBoard = (board: ElementType[][]) => {
+  const working: (ElementType | null)[][] = board.map(row => [...row]);
+  const combos: ComboDetail[] = [];
+  let scoreGain = 0;
+  let cascade = 0;
+
+  while (true) {
+    const { matchMask, groups } = findMatches(working as ElementType[][]);
+    if (groups.length === 0) {
+      break;
+    }
+
+    cascade += 1;
+    const cascadeMultiplier = 1 + (cascade - 1) * 0.25;
+
+    for (const group of groups) {
+      const size = group.cells.length;
+      const basePoints = 50 + size * 20;
+      const points = Math.round(basePoints * cascadeMultiplier);
+      scoreGain += points;
+      combos.push({
+        type: group.type,
+        size,
+        points,
+        cascade
+      });
+    }
+
+    for (let row = 0; row < BOARD_ROWS; row += 1) {
+      for (let col = 0; col < BOARD_COLS; col += 1) {
+        if (matchMask[row][col]) {
+          working[row][col] = null;
+        }
+      }
+    }
+
+    for (let col = 0; col < BOARD_COLS; col += 1) {
+      let writeRow = BOARD_ROWS - 1;
+      for (let row = BOARD_ROWS - 1; row >= 0; row -= 1) {
+        const cell = working[row][col];
+        if (cell !== null) {
+          working[writeRow][col] = cell;
+          if (writeRow !== row) {
+            working[row][col] = null;
+          }
+          writeRow -= 1;
+        }
+      }
+      for (let fillRow = writeRow; fillRow >= 0; fillRow -= 1) {
+        working[fillRow][col] = generateOrb(working, fillRow, col);
+      }
+    }
+  }
+
+  const finalBoard: ElementType[][] = working.map(row => row.map(cell => cell ?? randomOrb()));
+
+  return { board: finalBoard, combos, scoreGain };
+};
+
+const createEmptyDragSession = () => ({
+  active: false,
+  pointerId: null as number | null,
+  origin: null as CellPosition | null,
+  lastCell: null as CellPosition | null,
+  snapshot: null as ElementType[][] | null,
+  latestBoard: null as ElementType[][] | null,
+  moved: false
+});
+
+export const useGameEngine = (t: Translation, turnLimit: number | null) => {
+  const [board, setBoard] = useState<ElementType[][]>(() => createInitialBoard());
+  const boardStateRef = useRef(board);
+  const [selected, setSelected] = useState<CellPosition | null>(null);
+  const [score, setScore] = useState(0);
+  const [turns, setTurns] = useState<number>(turnLimit ?? MAX_TURNS);
+  const turnsRef = useRef(turns);
+  const [totalCombos, setTotalCombos] = useState(0);
+  const [lastCombos, setLastCombos] = useState<ComboDetail[]>([]);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    boardStateRef.current = board;
+  }, [board]);
+
+  useEffect(() => {
+    turnsRef.current = turns;
+  }, [turns]);
+
+  useEffect(() => {
+    setMessage(t.messageReady);
+  }, [t]);
+
+  const dragSessionRef = useRef(createEmptyDragSession());
+  const moveListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
+  const upListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
+  const cancelListenerRef = useRef<((event: PointerEvent) => void) | null>(null);
+
+  const cleanupGlobalListeners = () => {
+    if (moveListenerRef.current) {
+      window.removeEventListener('pointermove', moveListenerRef.current);
+      moveListenerRef.current = null;
+    }
+    if (upListenerRef.current) {
+      window.removeEventListener('pointerup', upListenerRef.current);
+      upListenerRef.current = null;
+    }
+    if (cancelListenerRef.current) {
+      window.removeEventListener('pointercancel', cancelListenerRef.current);
+      cancelListenerRef.current = null;
+    }
+  };
+
+  const resetDragSession = () => {
+    dragSessionRef.current = createEmptyDragSession();
+  };
+
+  useEffect(
+    () => () => {
+      cleanupGlobalListeners();
+    },
+    []
+  );
+
+  const handleReset = useCallback(() => {
+    cleanupGlobalListeners();
+    resetDragSession();
+    const freshBoard = createInitialBoard();
+    setBoard(freshBoard);
+    boardStateRef.current = freshBoard;
+    setSelected(null);
+    setScore(0);
+    const startingTurns = turnLimit ?? MAX_TURNS;
+    setTurns(startingTurns);
+    turnsRef.current = startingTurns;
+    setTotalCombos(0);
+    setLastCombos([]);
+    setMessage(t.messageReady);
+  }, [t, turnLimit]);
+
+  const handlePointerDown = useCallback((
+    event: ReactPointerEvent<HTMLButtonElement>,
+    row: number,
+    col: number
+  ) => {
+    if (turnLimit !== null && turnsRef.current <= 0) {
+      setMessage(t.outOfTurns);
+      return;
+    }
+
+    event.currentTarget.setPointerCapture(event.pointerId);
+
+    cleanupGlobalListeners();
+    resetDragSession();
+
+    dragSessionRef.current = {
+      active: true,
+      pointerId: event.pointerId,
+      origin: { row, col },
+      lastCell: { row, col },
+      snapshot: boardStateRef.current.map(r => [...r]),
+      latestBoard: boardStateRef.current.map(r => [...r]),
+      moved: false
+    };
+
+    setSelected({ row, col });
+
+    const handleMove = (moveEvent: PointerEvent) => {
+      const session = dragSessionRef.current;
+      if (!session.active || session.pointerId !== moveEvent.pointerId || !session.snapshot) {
+        return;
+      }
+
+      const target = moveEvent.target as HTMLElement | null;
+      const rowAttr = target?.getAttribute('data-row');
+      const colAttr = target?.getAttribute('data-col');
+      if (rowAttr == null || colAttr == null) {
+        return;
+      }
+
+      const newRow = Number.parseInt(rowAttr, 10);
+      const newCol = Number.parseInt(colAttr, 10);
+      if (
+        !Number.isInteger(newRow) ||
+        !Number.isInteger(newCol) ||
+        (newRow === session.lastCell?.row && newCol === session.lastCell?.col)
+      ) {
+        return;
+      }
+
+      const rowDelta = Math.abs(newRow - session.lastCell!.row);
+      const colDelta = Math.abs(newCol - session.lastCell!.col);
+      if (rowDelta + colDelta !== 1) {
+        return;
+      }
+
+      session.moved = true;
+      session.latestBoard = swapCells(
+        session.latestBoard ?? boardStateRef.current,
+        session.lastCell!,
+        {
+          row: newRow,
+          col: newCol
+        }
+      );
+      session.lastCell = { row: newRow, col: newCol };
+      setBoard(session.latestBoard);
+      setSelected({ row: newRow, col: newCol });
+    };
+
+    const handleUp = (upEvent: PointerEvent) => {
+      const session = dragSessionRef.current;
+      cleanupGlobalListeners();
+      if (!session.active || session.pointerId !== upEvent.pointerId || !session.snapshot) {
+        resetDragSession();
+        return;
+      }
+
+      const origin = session.origin;
+      const lastCell = session.lastCell;
+      const snapshot = session.snapshot;
+      const latestBoard = session.latestBoard;
+      resetDragSession();
+
+      if (!origin || !lastCell || !latestBoard) {
+        return;
+      }
+
+      if (!session.moved) {
+        setSelected(origin);
+        return;
+      }
+
+      const { board: resolvedBoard, combos, scoreGain } = resolveBoard(latestBoard);
+      const comboCount = combos.length;
+      if (comboCount === 0) {
+        setBoard(snapshot);
+        setSelected(origin);
+        setMessage(t.messageInvalidSwap);
+      } else {
+        setBoard(resolvedBoard);
+        setSelected(null);
+        setScore(prev => prev + scoreGain);
+        setTotalCombos(prev => prev + comboCount);
+        setLastCombos(combos);
+        setMessage(t.messageCombo(comboCount));
+        if (turnLimit !== null) {
+          setTurns(prev => Math.max(0, prev - 1));
+        }
+      }
+    };
+
+    const handleCancel = () => {
+      cleanupGlobalListeners();
+      resetDragSession();
+      setBoard(boardStateRef.current);
+      setSelected(null);
+    };
+
+    moveListenerRef.current = handleMove;
+    upListenerRef.current = handleUp;
+    cancelListenerRef.current = handleCancel;
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleCancel);
+  }, [handleReset, setMessage, turnLimit, t.messageCombo, t.messageInvalidSwap, t.outOfTurns]);
+
+  return {
+    board,
+    selected,
+    score,
+    turns,
+    totalCombos,
+    lastCombos,
+    message,
+    setMessage,
+    handleReset,
+    handlePointerDown
+  };
+};

--- a/math-dungeon-app/src/translations.ts
+++ b/math-dungeon-app/src/translations.ts
@@ -1,0 +1,136 @@
+import type { Translation } from './types';
+
+export const TRANSLATIONS: Record<'ja' | 'en' | 'es', Translation> = {
+  ja: {
+    languageName: '日本語',
+    gameTitle: 'さんすうダンジョン大ぼうけん',
+    subtitle: 'やさしい珠をならべかえて、連鎖でスコアを伸ばそう！',
+    languageSelectLabel: '表示言語',
+    moodLabel: 'あそびかたをえらぼう',
+    adventureTitle: '今日のチャレンジ',
+    adventureDescription:
+      '3コンボで「きらきらバッジ」、8コンボで「たいようバッジ」をゲット！たくさんコンボをつないで冒険をすすめよう。',
+    instructionsTitle: 'あそびかた',
+    instructions: [
+      'うごかしたい珠をタップしたまま、上下左右にスライドしよう。',
+      '指が通ったマスと入れかわるよ。はなした場所で盤面がきまるよ。',
+      'おなじ色が3つそろうと消えてポイントが入るよ。つづけて消えるとボーナス！'
+    ],
+    statsLabels: {
+      turns: 'のこりターン',
+      score: 'スコア',
+      combos: '合計コンボ'
+    },
+    lastComboTitle: 'さいごのコンボ',
+    noCombosYet: 'まだコンボはないよ。好きな珠を動かしてみよう！',
+    resetButton: 'リセットしてもう一度',
+    messageInvalidSwap: 'コンボができなかったので、もとにもどしたよ。',
+    messageCombo: comboCount => `${comboCount}コンボ！よくできました！`,
+    messageReady: '珠をスライドしてならべかえよう。',
+    outOfTurns: 'ターンがおわったよ。リセットして続けよう！',
+    elementNames: {
+      fire: 'ひ',
+      water: 'みず',
+      wood: 'き',
+      light: 'ひかり',
+      dark: 'やみ',
+      heart: 'ハート'
+    },
+    comboLineTemplate: 'コンボ{index}: {element} ×{count} (+{points}{unit}) / {cascade}',
+    pointsUnit: '点',
+    cascadeLabelTemplate: '{value}れんさ目',
+    practiceModeLabel: 'れんしゅうモード',
+    practiceModeOn: 'ずっとあそぶ (ターンむげん)',
+    practiceModeOff: 'ぼうけん (20ターン)',
+    questLabel: 'バッジまであと{value}コンボ',
+    questComplete: 'バッジをぜんぶ集めたよ！つぎのコンボもねらおう！'
+  },
+  en: {
+    languageName: 'English',
+    gameTitle: 'Math Adventure Dungeon',
+    subtitle: 'Slide friendly orbs, clear combos, and cheer for big chains!',
+    languageSelectLabel: 'Language',
+    moodLabel: 'Play style',
+    adventureTitle: 'Today’s quest',
+    adventureDescription:
+      'Earn the Sparkle Badge at 3 combos and the Sun Badge at 8 combos. Keep chaining matches to climb the adventure trail!',
+    instructionsTitle: 'How to play',
+    instructions: [
+      'Press and hold an orb, then slide across the grid in straight lines.',
+      'Every tile you pass swaps automatically. Release to lock in the board.',
+      'Match three or more of the same color to clear them. Chains add bonus points!'
+    ],
+    statsLabels: {
+      turns: 'Turns left',
+      score: 'Score',
+      combos: 'Total combos'
+    },
+    lastComboTitle: 'Latest combo chain',
+    noCombosYet: 'No combos yet—try sliding an orb!',
+    resetButton: 'Reset and try again',
+    messageInvalidSwap: 'No combo was formed, so the board was restored.',
+    messageCombo: comboCount => (comboCount === 1 ? 'Nice combo!' : `${comboCount} combos!`),
+    messageReady: 'Slide orbs to rearrange them.',
+    outOfTurns: 'You are out of turns. Reset to keep playing!',
+    elementNames: {
+      fire: 'Fire',
+      water: 'Water',
+      wood: 'Wood',
+      light: 'Light',
+      dark: 'Dark',
+      heart: 'Heart'
+    },
+    comboLineTemplate: 'Combo {index}: {element} ×{count} (+{points}{unit}) • {cascade}',
+    pointsUnit: 'pts',
+    cascadeLabelTemplate: 'Cascade {value}',
+    practiceModeLabel: 'Practice mode',
+    practiceModeOn: 'Free play (no turn limit)',
+    practiceModeOff: 'Adventure (20 turns)',
+    questLabel: '{value} combos to next badge',
+    questComplete: 'All badges collected—keep the chain going!'
+  },
+  es: {
+    languageName: 'Español',
+    gameTitle: 'Mazmorra de Aventuras',
+    subtitle: 'Desliza esferas amigas, crea combos y celebra las cadenas.',
+    languageSelectLabel: 'Idioma',
+    moodLabel: 'Modo de juego',
+    adventureTitle: 'Misión de hoy',
+    adventureDescription:
+      'Gana la Insignia Brillante con 3 combos y la Insignia Sol con 8 combos. ¡Sigue encadenando para avanzar en la aventura!',
+    instructionsTitle: 'Cómo jugar',
+    instructions: [
+      'Mantén pulsada una esfera y deslízala en línea recta por la cuadrícula.',
+      'Cada casilla que atraviesas se intercambia sola. Al soltar, el tablero se fija.',
+      'Une tres o más del mismo color para despejarlas. Las cadenas suman más puntos.'
+    ],
+    statsLabels: {
+      turns: 'Turnos restantes',
+      score: 'Puntuación',
+      combos: 'Combos totales'
+    },
+    lastComboTitle: 'Cadena más reciente',
+    noCombosYet: 'Aún no hay combos. ¡Desliza una esfera!',
+    resetButton: 'Reiniciar y jugar otra vez',
+    messageInvalidSwap: 'No hubo combo; el tablero volvió a su estado anterior.',
+    messageCombo: comboCount => (comboCount === 1 ? '¡Buen combo!' : `¡${comboCount} combos!`),
+    messageReady: 'Desliza las esferas para reordenarlas.',
+    outOfTurns: 'No quedan turnos. ¡Reinicia para seguir!',
+    elementNames: {
+      fire: 'Fuego',
+      water: 'Agua',
+      wood: 'Bosque',
+      light: 'Luz',
+      dark: 'Oscuridad',
+      heart: 'Corazón'
+    },
+    comboLineTemplate: 'Combo {index}: {element} ×{count} (+{points}{unit}) • {cascade}',
+    pointsUnit: 'pts',
+    cascadeLabelTemplate: 'Cadena {value}',
+    practiceModeLabel: 'Modo práctica',
+    practiceModeOn: 'Juego libre (sin turnos)',
+    practiceModeOff: 'Aventura (20 turnos)',
+    questLabel: '{value} combos hasta la próxima insignia',
+    questComplete: '¡Todas las insignias conseguidas! ¡Sigue encadenando!'
+  }
+};

--- a/math-dungeon-app/src/types.ts
+++ b/math-dungeon-app/src/types.ts
@@ -1,0 +1,48 @@
+export type ElementType = 'fire' | 'water' | 'wood' | 'light' | 'dark' | 'heart';
+
+export type CellPosition = {
+  row: number;
+  col: number;
+};
+
+export type ComboDetail = {
+  type: ElementType;
+  size: number;
+  points: number;
+  cascade: number;
+};
+
+export type Translation = {
+  languageName: string;
+  gameTitle: string;
+  subtitle: string;
+  languageSelectLabel: string;
+  moodLabel: string;
+  adventureTitle: string;
+  adventureDescription: string;
+  instructionsTitle: string;
+  instructions: string[];
+  statsLabels: {
+    turns: string;
+    score: string;
+    combos: string;
+  };
+  lastComboTitle: string;
+  noCombosYet: string;
+  resetButton: string;
+  messageInvalidSwap: string;
+  messageCombo: (comboCount: number) => string;
+  messageReady: string;
+  outOfTurns: string;
+  elementNames: Record<ElementType, string>;
+  comboLineTemplate: string;
+  pointsUnit: string;
+  cascadeLabelTemplate: string;
+  practiceModeLabel: string;
+  practiceModeOn: string;
+  practiceModeOff: string;
+  questLabel: string;
+  questComplete: string;
+};
+
+export type Locale = 'ja' | 'en' | 'es';

--- a/math-dungeon-app/src/utils/format.ts
+++ b/math-dungeon-app/src/utils/format.ts
@@ -1,0 +1,2 @@
+export const formatTemplate = (template: string, params: Record<string, string | number>) =>
+  template.replace(/\{(\w+)\}/g, (match, key) => (key in params ? String(params[key]) : match));


### PR DESCRIPTION
## Summary
- Rebuilt the math adventure app into modular components with a kid-friendly practice/adventure toggle and quest tracker
- Updated translations and copy to be simpler and motivating for young players across supported languages
- Refreshed the visual theme with brighter, playful styling and clear stat panels

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455b7b6dd48328a503eb4abf6f64ae)